### PR TITLE
Fix cache in the .travis.yml file for faster building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .idea
 simphony_ui.egg-info/
-simphony_ui/OpenFoam_input.pyc
-simphony_ui/__init__.pyc
-simphony_ui/couple_CFDDEM.pyc
+*.pyc
 travis.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .idea
+simphony_ui.egg-info/
+simphony_ui/OpenFoam_input.pyc
+simphony_ui/__init__.pyc
+simphony_ui/couple_CFDDEM.pyc
+travis.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
 .idea
-simphony_ui.egg-info/
-*.pyc
-travis.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
   directories:
     - "$HOME/.ccache"
     - "$HOME/simphony"
-    - "/var/cache/apt/archives"
+    - "$HOME/debcache"
 
 before_install:
   - ccache -s
@@ -31,6 +31,8 @@ before_install:
   - git clone --branch=0.3.1 https://github.com/simphony/simphony-framework.git $HOME/simphony-framework
   - pushd $HOME/simphony-framework
   - sudo make base
+  - if [! -e $HOME/debcache/openfoam231_0-1_amd64.deb ]; then wget http://dl.openfoam.org/ubuntu/dists/trusty/main/binary-amd64/openfoam231_0-1_amd64.deb -O $HOME/debcache/openfoam231_0-1_amd64.deb; fi
+  - cp $HOME/debcache/openfoam231_0-1_amd64.deb /var/cache/apt/archives/
   - sudo make apt-openfoam-deps
   - sudo make apt-simphony-deps
   - sudo make apt-lammps-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - sudo ln -s ccache /usr/local/bin/mpic++
   - make simphony-env
   - make lammps
-#  - source ~/simphony/bin/activate
+  - source ~/simphony/bin/activate
 #  - make simphony-common
 #  - make simphony-mayavi
 #  - make simphony-openfoam

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ before_install:
   - make simphony-env
   - make lammps
   - source ~/simphony/bin/activate
-#  - make simphony-common
-#  - make simphony-mayavi
-#  - make simphony-openfoam
+  - make simphony-common
+  - make simphony-mayavi
+  - make simphony-openfoam
 #  - make simphony-liggghts
 #  - make simphony-lammps
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
   directories:
     - "$HOME/.ccache"
     - "$HOME/simphony"
+    - "/var/cache/apt/archives"
 
 before_install:
   - ccache -s
@@ -49,4 +50,4 @@ install:
 #  - pip install -r dev_requirements.txt
 #  - python -c "import simphony"
 script:
-  - flake8 .
+#  - flake8 .

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,8 @@ before_install:
 #  - make simphony-lammps
 #  - popd
 install:
-#  - pip install -r dev_requirements.txt
+  - pip install -r dev_requirements.txt
 #  - python -c "import simphony"
 script:
-#  - flake8 .
+  - flake8 .
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - git clone --branch=0.3.1 https://github.com/simphony/simphony-framework.git $HOME/simphony-framework
   - pushd $HOME/simphony-framework
   - sudo make base
-  - if [! -e $HOME/debcache/openfoam231_0-1_amd64.deb ]; then wget http://dl.openfoam.org/ubuntu/dists/trusty/main/binary-amd64/openfoam231_0-1_amd64.deb -O $HOME/debcache/openfoam231_0-1_amd64.deb; fi
+  - if test ! -e $HOME/debcache/openfoam231_0-1_amd64.deb; then wget http://dl.openfoam.org/ubuntu/dists/trusty/main/binary-amd64/openfoam231_0-1_amd64.deb -O $HOME/debcache/openfoam231_0-1_amd64.deb; fi
   - cp $HOME/debcache/openfoam231_0-1_amd64.deb /var/cache/apt/archives/
   - sudo make apt-openfoam-deps
   - sudo make apt-simphony-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,12 @@ before_install:
   - sudo make base
   - sudo make apt-openfoam-deps
   - sudo make apt-simphony-deps
-#  - sudo make apt-lammps-deps
-#  - sudo make fix-pip
-#  - sudo make apt-mayavi-deps
-#  - sudo ln -s ccache /usr/local/bin/mpic++
-#  - make simphony-env
-#  - make lammps
+  - sudo make apt-lammps-deps
+  - sudo make fix-pip
+  - sudo make apt-mayavi-deps
+  - sudo ln -s ccache /usr/local/bin/mpic++
+  - make simphony-env
+  - make lammps
 #  - source ~/simphony/bin/activate
 #  - make simphony-common
 #  - make simphony-mayavi

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - pushd $HOME/simphony-framework
   - sudo make base
   - if test ! -e $HOME/debcache/openfoam231_0-1_amd64.deb; then wget http://dl.openfoam.org/ubuntu/dists/trusty/main/binary-amd64/openfoam231_0-1_amd64.deb -O $HOME/debcache/openfoam231_0-1_amd64.deb; fi
-  - cp $HOME/debcache/openfoam231_0-1_amd64.deb /var/cache/apt/archives/
+  - sudo cp $HOME/debcache/openfoam231_0-1_amd64.deb /var/cache/apt/archives/
   - sudo make apt-openfoam-deps
   - sudo make apt-simphony-deps
   - sudo make apt-lammps-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
 #  - make simphony-openfoam
 #  - make simphony-liggghts
 #  - make simphony-lammps
-#  - popd
+  - popd
 install:
   - pip install -r dev_requirements.txt
 #  - python -c "import simphony"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ before_install:
   - make simphony-common
   - make simphony-mayavi
   - make simphony-openfoam
-#  - make simphony-liggghts
-#  - make simphony-lammps
+  - make simphony-liggghts
+  - make simphony-lammps
   - popd
 install:
   - pip install -r dev_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,21 +32,21 @@ before_install:
   - sudo make base
   - sudo make apt-openfoam-deps
   - sudo make apt-simphony-deps
-  - sudo make apt-lammps-deps
-  - sudo make fix-pip
-  - sudo make apt-mayavi-deps
-  - sudo ln -s ccache /usr/local/bin/mpic++
-  - make simphony-env
-  - make lammps
-  - source ~/simphony/bin/activate
-  - make simphony-common
-  - make simphony-mayavi
-  - make simphony-openfoam
-  - make simphony-liggghts
-  - make simphony-lammps
-  - popd
+#  - sudo make apt-lammps-deps
+#  - sudo make fix-pip
+#  - sudo make apt-mayavi-deps
+#  - sudo ln -s ccache /usr/local/bin/mpic++
+#  - make simphony-env
+#  - make lammps
+#  - source ~/simphony/bin/activate
+#  - make simphony-common
+#  - make simphony-mayavi
+#  - make simphony-openfoam
+#  - make simphony-liggghts
+#  - make simphony-lammps
+#  - popd
 install:
-  - pip install -r dev_requirements.txt
-  - python -c "import simphony"
+#  - pip install -r dev_requirements.txt
+#  - python -c "import simphony"
 script:
   - flake8 .


### PR DESCRIPTION
Fixing cache build to speed up downloading of openfoam and build of C components.